### PR TITLE
Nissix plugin scope-packages on wow-demos

### DIFF
--- a/animation-playground/index.html
+++ b/animation-playground/index.html
@@ -58,8 +58,8 @@
         </div>
     </div>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/2.1.3/TweenMax.min.js"></script>
-    <script src="https://static.parastorage.com/unpkg/santa-core-utils@1.2513.0/dist/tweenEngine2.js"></script>
-    <script src="https://static.parastorage.com/unpkg/santa-animations@1.472.0/dist/santa-animations.js"></script>
+    <script src="https://static.parastorage.com/unpkg/@wix/santa-core-utils@1.2513.0/dist/tweenEngine2.js"></script>
+    <script src="https://static.parastorage.com/unpkg/@wix/santa-animations@1.472.0/dist/santa-animations.js"></script>
     <script src="./playground.js"></script>
 </body>
 

--- a/animation-playground/index3.html
+++ b/animation-playground/index3.html
@@ -58,8 +58,8 @@
         </div>
     </div>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.2.6/gsap.min.js"></script>
-    <script src="https://static.parastorage.com/unpkg/santa-core-utils@1.2513.0/dist/tweenEngine3.js"></script>
-    <script src="https://static.parastorage.com/unpkg/santa-animations@1.477.0/dist/santa-animations.js"></script>
+    <script src="https://static.parastorage.com/unpkg/@wix/santa-core-utils@1.2513.0/dist/tweenEngine3.js"></script>
+    <script src="https://static.parastorage.com/unpkg/@wix/santa-animations@1.477.0/dist/santa-animations.js"></script>
     <script src="playground.js"></script>
 </body>
 


### PR DESCRIPTION
Hi, I'm Nissix, the automated PR bot!

Wix is moving its internal packages to the @wix scope (but still in the internal registry). Publishing new unscoped internal packages is no longer allowed, and all existing packages are moving to @wix. This means changing package names, and also all usages of those packages to their @wix scope version.

This PR is an automatic codemod that moves all of your packages to @wix scope, and changes any usages (`pacakge.json`, imports, requires, etc..) to their @wix version.

| :bangbang: | This codemod is best-effort! Meaning it may not have found and fixed all usages, but it did change your package.jsons. So go over the changes carefully and test this version carefully  |
| :--------: | :----------------------------------------------------------------------------------------------------- |

If you want to know why we don't support publishing unscoped to the internal registry, check out this article on [Dependency Confusion](https://medium.com/@alex.birsan/dependency-confusion-4a5d60fec610)

If you are unsure, need help or have questions, reach us at #wix-scope-migration

Error Log:
npx: installed 234 in 6.508s



Output Log:
Migrating package "wow-demos" in .


## Migration from non scope to @wix/scoped packages
> /tmp/452f43dec4f0b059bcdaa9e3c3c56e6b

#### replace unpkg & node_modules script tags in html and templates
```
animation-playground/index.html
animation-playground/index3.html
```

